### PR TITLE
feat: add mTLS gRPC server/cli, cgroup v2 enforcement, and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,69 @@
 .PHONY: all help proto proto.clean certs certs.clean server user clean \
-        chroot chroot.clean chroot.nuke
+        chroot chroot.clean chroot.nuke \
+        deps tidy fmt vet test build build.bin install \
+        jobctl jobworker-server run.server run.server.sudo
+
 .DEFAULT_GOAL := all
 
 CHROOT_SCRIPT := ./scripts/chroot.sh
 
-# ---- Default (build everything except chroot cleanup) ----
-all: proto certs chroot
+LOG_PATH ?= $(abspath ./jobworker-server.log)
+
+# ---- Go build settings ----
+GO       ?= go
+BIN_DIR  ?= ./bin
+JOBCTL_BIN := $(BIN_DIR)/jobctl
+SERVER_BIN := $(BIN_DIR)/jobworker-server
+
+# Rebuild binaries whenever any Go source changes
+GO_FILES := $(shell find cmd internal proto -name '*.go' -type f)
+
+
+# Packages (explicit so you don't accidentally build ./... into many mains)
+JOBCTL_PKG := ./cmd/jobctl
+SERVER_PKG := ./cmd/jobworker-server
+
+# ---- Default: build everything you need to run locally ----
+
+## NOTE: add chroot to enable building of chroot jail when needed
+all: proto certs build
+	@echo ">>> all complete"
 
 # ---- Help ----
 help:
-	@echo "Default: make                 -> proto + certs + chroot (build)"
+	@echo "Default: make                        -> proto + certs + chroot + build binaries"
 	@echo "Targets:"
-	@echo "  help                        - show this help"
-	@echo "  all                         - same as 'make' (proto + certs + chroot build)"
-	@echo "  proto                       - generate protobufs"
-	@echo "  proto.clean                 - clean generated protobufs"
-	@echo "  certs                       - run 'make all' in certs/"
-	@echo "  certs server                - run 'make server' in certs/"
-	@echo "  certs user                  - run 'make user' in certs/"
-	@echo "  certs clean                 - run 'make clean' in certs/"
-	@echo "  chroot                      - build minimal chroot (calls '$(CHROOT_SCRIPT) build')"
-	@echo "  chroot.clean                - unmount & remove chroot (calls '$(CHROOT_SCRIPT) clean')"
-	@echo "  chroot.nuke                 - force cleanup (calls '$(CHROOT_SCRIPT) nuke')"
-	@echo "  clean                       - clean proto + certs (does NOT touch chroot)"
+	@echo "  help                               - show this help"
+	@echo "  all                                - proto + certs + chroot + build"
+	@echo ""
+	@echo "Go build/test:"
+	@echo "  deps                               - download deps"
+	@echo "  tidy                               - go mod tidy"
+	@echo "  fmt                                - gofmt ./..."
+	@echo "  vet                                - go vet ./..."
+	@echo "  test                               - go test ./..."
+	@echo "  build                              - build both binaries into $(BIN_DIR)/"
+	@echo "  jobctl                             - build jobctl only"
+	@echo "  jobworker-server                   - build server only"
+	@echo "  install                            - go install both binaries"
+	@echo ""
+	@echo "Proto:"
+	@echo "  proto                              - generate protobufs"
+	@echo "  proto.clean                        - clean generated protobufs"
+	@echo ""
+	@echo "Certs:"
+	@echo "  certs                              - run 'make all' in certs/"
+	@echo "  make certs server                  - run 'make server' in certs/"
+	@echo "  make certs user                    - run 'make user' in certs/"
+	@echo "  certs.clean                        - run 'make clean' in certs/"
+	@echo ""
+	@echo "Chroot:"
+	@echo "  chroot                             - build minimal chroot (calls '$(CHROOT_SCRIPT) build')"
+	@echo "  chroot.clean                       - unmount & remove chroot (calls '$(CHROOT_SCRIPT) clean')"
+	@echo "  chroot.nuke                        - force cleanup (calls '$(CHROOT_SCRIPT) nuke')"
+	@echo ""
+	@echo "Run:"
+	@echo "  run.server                         - run server (as root)"
 
 # ---- Proto ----
 proto:
@@ -32,6 +73,9 @@ proto.clean:
 	@./scripts/generate_proto.sh clean
 
 # ---- Certs namespace ----
+# Allows: make certs          (defaults to certs/all)
+#         make certs server   (runs certs/server)
+#         make certs user     (runs certs/user)
 certs:
 	@$(MAKE) -C certs $(if $(filter-out $@,$(MAKECMDGOALS)),$(filter-out $@,$(MAKECMDGOALS)),all)
 
@@ -51,6 +95,54 @@ chroot.clean:
 chroot.nuke:
 	@$(CHROOT_SCRIPT) nuke
 
+# ---- Go deps & hygiene ----
+deps:
+	@$(GO) mod download
+
+tidy:
+	@$(GO) mod tidy
+
+fmt:
+	@$(GO) fmt ./...
+
+vet:
+	@$(GO) vet ./...
+
+test:
+	@$(GO) test ./...
+
+# ---- Build binaries ----
+build: build.bin
+
+build.bin: $(JOBCTL_BIN) $(SERVER_BIN)
+	@echo ">>> built: $(JOBCTL_BIN) $(SERVER_BIN)"
+
+$(BIN_DIR):
+	@mkdir -p $(BIN_DIR)
+
+jobctl: $(JOBCTL_BIN)
+jobworker-server: $(SERVER_BIN)
+
+$(JOBCTL_BIN): $(GO_FILES) | $(BIN_DIR)
+	@echo ">>> building jobctl -> $(JOBCTL_BIN)"
+	@$(GO) build -o $(JOBCTL_BIN) $(JOBCTL_PKG)
+
+$(SERVER_BIN): $(GO_FILES) | $(BIN_DIR)
+	@echo ">>> building jobworker-server -> $(SERVER_BIN)"
+	@$(GO) build -o $(SERVER_BIN) $(SERVER_PKG)
+
+# Optional: install into GOPATH/bin
+install:
+	@echo ">>> go install jobctl and jobworker-server"
+	@$(GO) install $(JOBCTL_PKG)
+	@$(GO) install $(SERVER_PKG)
+
+# ---- Run server ----
+run.server: build
+	@sudo fuser -k 50051/tcp >/dev/null 2>&1 || true
+	@sudo $(SERVER_BIN) -listen :50051 -certs ./certs -log $(LOG_PATH)
+
 # ---- Global clean (does NOT touch chroot) ----
 clean: proto.clean certs.clean
-	@echo ">>> clean complete"
+	@rm -rf $(BIN_DIR)
+	@echo ">>> clean complete (kept chroot)"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,255 @@
+# JobWorker (Go)
+
+JobWorker is a gRPC-based job execution service and CLI for running controlled host-level jobs with strong process isolation, disk-backed output, and per-job resource limits using Linux cgroups v2.
+
+It is a systems-level job runner (not a container runtime) built on native Linux primitives:
+- processes
+- cgroups v2
+- procfs
+- privilege dropping
+- process groups
+- kernel-enforced resource control
+- TLS-secured gRPC transport
+
+Repo: https://github.com/bucknercd/jobworker
+
+---
+
+## Overview
+
+JobWorker consists of two components:
+
+- **jobworker-server**  
+  A gRPC server that manages job lifecycle, execution, isolation, logging, and cleanup.
+
+- **jobctl**  
+  A CLI client for starting jobs, checking status, stopping jobs, and streaming output.
+
+Jobs execute directly on the host and are isolated using:
+- Linux process groups
+- Linux cgroups v2 (CPU, memory, IO, pids)
+- privilege dropping (`nobody:nogroup`)
+- per-job filesystem directories
+- disk-backed stdout/stderr
+- TLS-secured gRPC communication
+
+---
+
+## Execution Model
+
+- Jobs run directly on the host (no containers)
+- Each job runs in:
+  - its own process group
+  - its own cgroup v2 subtree
+- Jobs are launched with:
+  - `UseCgroupFD` (atomic cgroup attachment)
+  - `Setpgid=true` (separate process group)
+  - `Pdeathsig=SIGKILL` (child dies if server dies)
+  - dropped privileges (`nobody:nogroup`)
+- Output is written directly to disk
+
+---
+
+## Output Model (Source of Truth)
+
+Each job has disk-backed output:
+
+/var/lib/jobs/<job-id>/stdout.log
+/var/lib/jobs/<job-id>/stderr.log
+
+markdown
+Copy code
+
+Behavior:
+- stdout/stderr are written directly to disk
+- on job completion:
+  - server reads these files
+  - dumps their contents into the server log
+- disk files are the source of truth
+- the server also writes a centralized log file in the repo root:
+
+./jobworker-server.log
+
+---
+
+## Cgroup Isolation (Core Feature)
+
+Each job runs inside a dedicated cgroup v2 directory:
+
+/sys/fs/cgroup/jobs/<job-id>
+
+markdown
+Copy code
+
+Supported controllers:
+- `cpu.max`
+- `memory.max`
+- `io.max`
+- `pids.current`
+
+Features:
+- per-job CPU limits
+- per-job memory limits
+- per-job IO throttling (device/kernel dependent)
+- per-job accounting (`cpu.stat`, `memory.current`)
+- atomic attachment via `UseCgroupFD`
+- forced termination via `cgroup.kill`
+
+The server logs:
+- job ID
+- OS PID
+- cgroup path
+- attached PIDs
+- configured limits
+- live usage
+- throttling counters
+
+This provides runtime verification that enforcement is active.
+
+---
+
+## Security Model & Disclaimer
+
+JobWorker is not a sandbox and not a container runtime.
+
+Security properties:
+- jobs run as `nobody:nogroup`
+- privilege dropping enforced
+- per-job cgroup isolation
+- per-job process group isolation
+- TLS gRPC transport
+- disk-backed output
+
+Limitations:
+- no chroot isolation enabled
+- no containerization
+- no namespace isolation
+- jobs execute on the host filesystem
+- host access is possible unless externally restricted
+
+This is a controlled execution system, not a hardened sandbox.
+
+---
+
+## Feature Matrix
+
+| Feature                   | Status |
+|---------------------------|--------|
+| gRPC API                  | Implemented |
+| TLS transport             | Implemented |
+| CLI (`jobctl`)            | Implemented |
+| Disk-backed output        | Implemented |
+| Post-exec log dumping     | Implemented |
+| Process groups            | Implemented |
+| Pdeathsig cleanup         | Implemented |
+| Privilege dropping        | Implemented |
+| Cgroup v2 isolation       | Implemented |
+| CPU limits                | Implemented |
+| Memory limits             | Implemented |
+| IO throttling             | Implemented (device/kernel dependent) |
+| Streaming output          | Not implemented |
+| chroot isolation          | Not enabled |
+| Container runtime         | Not used |
+| Namespace isolation       | Not used |
+
+---
+
+## Build & Run
+
+### Build everything
+```bash
+make all
+```
+
+### Run Server
+
+- Default
+```bash
+make run.server
+```
+- Custom listen address, certs path, log path
+```bash
+sudo ./bin/jobworker-server -listen :50051 -certs ./certs -log ./jobworker-server.log
+```
+
+### Run Client
+```bash
+make certs user
+```
+- then run `jobctl` commands as shown below
+
+### Generate TLS certificates
+bash
+make certs server
+make certs user
+
+## CLI Usage (jobctl)
+```bash
+./bin/jobctl --help
+./bin/jobctl -cmd start -exe sleep -args "10"
+```
+
+### Start with CPU + memory limits
+```bash
+./bin/jobctl \
+  -cmd start \
+  -exe bash \
+  -args "-c 'yes > /dev/null'" \
+  -cpu 500m \
+  -mem 100M
+```
+
+### Start with IO class
+```bash
+./bin/jobctl -cmd start -exe ls -args "-lah /" -io low
+./bin/jobctl -cmd status -id <job-id>
+```
+
+### Stop a job
+```bash
+./bin/jobctl -cmd stop -id <job-id>
+```
+
+---
+
+## Observability
+
+For each job, the server logs:
+
+- job ID  
+- OS PID  
+- cgroup path  
+- attached PIDs  
+- configured limits  
+- live usage  
+- throttling counters  
+- stdout/stderr dump on completion  
+
+This provides auditable, verifiable enforcement and execution tracing.
+
+---
+
+## Design Philosophy
+
+JobWorker is built on native kernel primitives rather than container abstractions:
+
+- Linux process model  
+- cgroups v2  
+- procfs  
+- syscall-level control  
+- privilege separation  
+- explicit resource enforcement  
+- deterministic execution  
+- observable state  
+
+It is designed to be:
+
+- debuggable  
+- inspectable  
+- auditable  
+- systems-oriented  
+- infrastructure-first  
+- correctness-driven
+- minimal dependencies
+- transparent in behavior
+  

--- a/certs/Makefile
+++ b/certs/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 CERTS_DIR := $(CURDIR)
 CA_KEY := $(CERTS_DIR)/ca.key
 CA_CERT := $(CERTS_DIR)/ca.crt
@@ -6,6 +8,14 @@ SERVER_KEY := $(CERTS_DIR)/server.key
 SERVER_CSR := $(CERTS_DIR)/server.csr
 SERVER_CERT := $(CERTS_DIR)/server.crt
 
+# ---- Configurable SANs ----
+# Default SANs for local dev:
+#   make server
+# Override examples:
+#   make server SERVER_SANS="DNS:jobworker.local,DNS:jobworker"
+#   make server SERVER_SANS="IP:10.0.0.12,DNS:jobworker.internal"
+SERVER_SANS ?= IP:127.0.0.1,DNS:localhost
+# --------------------------
 .PHONY: all server user clean
 
 all: server
@@ -20,14 +30,16 @@ $(CA_KEY) $(CA_CERT):
 
 server: $(CA_KEY) $(CA_CERT)
 	@if [ ! -f $(SERVER_KEY) ]; then \
-		echo ">>> Generating server certs"; \
+		echo ">>> Generating server certs (SANs: $(SERVER_SANS))"; \
 		openssl genrsa -out $(SERVER_KEY) 2048; \
 		openssl req -new -key $(SERVER_KEY) \
 			-subj "/CN=mtls-server" \
+			-addext "subjectAltName=$(SERVER_SANS)" \
 			-out $(SERVER_CSR); \
 		openssl x509 -req -in $(SERVER_CSR) \
 			-CA $(CA_CERT) -CAkey $(CA_KEY) -CAcreateserial \
-			-out $(SERVER_CERT) -days 365 -sha256; \
+			-out $(SERVER_CERT) -days 365 -sha256 \
+			-extfile <(printf "subjectAltName=$(SERVER_SANS)\nkeyUsage=digitalSignature,keyEncipherment\nextendedKeyUsage=serverAuth"); \
 		rm $(SERVER_CSR); \
 	else echo ">>> Server certs already exist, skipping."; fi
 

--- a/cmd/jobctl/main.go
+++ b/cmd/jobctl/main.go
@@ -1,0 +1,292 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	jobpb "github.com/bucknercd/jobworker/proto/gen/jobpb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+func main() {
+	var (
+		addr     = flag.String("addr", "127.0.0.1:50051", "jobworker server address")
+		certsDir = flag.String("certs", "./certs", "certs directory")
+		cmd      = flag.String("cmd", "", "command: start|status|stop|stream")
+		jobID    = flag.String("id", "", "job id for status/stop/stream")
+		target   = flag.String("target", "stdout", "stream target: stdout|stderr")
+		insecure = flag.Bool("insecure", false, "skip TLS verification (dev only)")
+		// start params
+		exe  = flag.String("exe", "", "executable for start (e.g. ls or /bin/ls)")
+		args = flag.String("args", "", "args for start, single string (e.g. \"-lah /\")")
+		cpu  = flag.String("cpu", "", "cpu limit (e.g. 500m, 2, max)")
+		mem  = flag.String("mem", "", "memory limit (e.g. 100M, max)")
+		ioCl = flag.String("io", "", "io class (low|med|high)")
+	)
+	flag.Parse()
+
+	if *cmd == "" {
+		die("missing -cmd (start|status|stop|stream)")
+	}
+
+	tlsCfg, err := buildClientTLSConfig(*certsDir, *addr, *insecure)
+	if err != nil {
+		die("tls config: %v", err)
+	}
+
+	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)))
+	if err != nil {
+		die("dial %s: %v", *addr, err)
+	}
+	defer conn.Close()
+
+	client := jobpb.NewJobWorkerClient(conn)
+
+	switch *cmd {
+	case "start":
+		if *exe == "" {
+			die("start requires -exe")
+		}
+		// NOTE: args parsing is minimal; later swap to cobra and proper arg splitting.
+		req := &jobpb.StartJobRequest{
+			Executable: *exe,
+			Args:       splitArgs(*args),
+			Limits: &jobpb.ResourceLimits{
+				Cpu:       *cpu,
+				MemoryMax: *mem,
+				IoClass:   *ioCl,
+			},
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		resp, err := client.StartJob(ctx, req)
+		if err != nil {
+			die("StartJob: %v", err)
+		}
+		fmt.Println(resp.GetJobId())
+
+	case "status":
+		if *jobID == "" {
+			die("status requires -id")
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		resp, err := client.GetStatus(ctx, &jobpb.GetStatusRequest{JobId: *jobID})
+		if err != nil {
+			die("GetStatus: %v", err)
+		}
+		fmt.Printf("job_id=%s status=%s exit_code=%d\n",
+			resp.GetJobId(),
+			resp.GetMetadata().GetStatus().String(),
+			resp.GetMetadata().GetExitCode(),
+		)
+
+	case "stop":
+		if *jobID == "" {
+			die("stop requires -id")
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		resp, err := client.StopJob(ctx, &jobpb.StopJobRequest{JobId: *jobID})
+		if err != nil {
+			die("StopJob: %v", err)
+		}
+		fmt.Printf("status=%s exit_code=%d\n",
+			resp.GetMetadata().GetStatus().String(),
+			resp.GetMetadata().GetExitCode(),
+		)
+
+	case "stream":
+		if *jobID == "" {
+			die("stream requires -id")
+		}
+
+		var t jobpb.StreamTarget
+		switch *target {
+		case "stdout":
+			t = jobpb.StreamTarget_STREAM_TARGET_STDOUT
+		case "stderr":
+			t = jobpb.StreamTarget_STREAM_TARGET_STDERR
+		default:
+			die("invalid -target (stdout|stderr)")
+		}
+
+		ctx := context.Background()
+		stream, err := client.StreamOutput(ctx, &jobpb.StreamOutputRequest{
+			JobId:  *jobID,
+			Target: t,
+		})
+		if err != nil {
+			die("StreamOutput: %v", err)
+		}
+
+		for {
+			msg, err := stream.Recv()
+			if err != nil {
+				if err == io.EOF {
+					return
+				}
+				die("stream recv: %v", err)
+			}
+			os.Stdout.Write(msg.GetChunk())
+		}
+
+	default:
+		die("unknown -cmd: %s", *cmd)
+	}
+}
+
+func die(format string, args ...any) {
+	log.Printf(format, args...)
+	os.Exit(1)
+}
+
+func splitArgs(s string) []string {
+	// minimal: split on spaces (no quotes handling)
+	if s == "" {
+		return nil
+	}
+	var out []string
+	cur := ""
+	inSpace := true
+	for _, r := range s {
+		if r == ' ' || r == '\t' || r == '\n' {
+			if !inSpace {
+				out = append(out, cur)
+				cur = ""
+			}
+			inSpace = true
+			continue
+		}
+		inSpace = false
+		cur += string(r)
+	}
+	if cur != "" {
+		out = append(out, cur)
+	}
+	return out
+}
+
+// func buildClientTLSConfig(certsDir, user, addr string) (*tls.Config, error) {
+// 	// client cert
+// 	clientCertPath := filepath.Join(certsDir, user, "client.crt")
+// 	clientKeyPath := filepath.Join(certsDir, user, "client.key")
+// 	clientCert, err := tls.LoadX509KeyPair(clientCertPath, clientKeyPath)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("load client keypair: %w", err)
+// 	}
+
+// 	// trust server CA
+// 	caPath := filepath.Join(certsDir, "ca.crt")
+// 	caPEM, err := os.ReadFile(caPath)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("read ca.crt: %w", err)
+// 	}
+// 	roots := x509.NewCertPool()
+// 	if ok := roots.AppendCertsFromPEM(caPEM); !ok {
+// 		return nil, fmt.Errorf("append ca.crt: no certs found")
+// 	}
+
+// 	host := addr
+// 	// addr might be "host:port"
+// 	if h, _, err := net.SplitHostPort(addr); err == nil {
+// 		host = h
+// 	}
+
+// 	return &tls.Config{
+// 		MinVersion:   tls.VersionTLS13,
+// 		Certificates: []tls.Certificate{clientCert},
+// 		RootCAs:      roots,
+
+// 		// IMPORTANT:
+// 		// Your server cert CN is "mtls-server". If you don't set ServerName,
+// 		// Go may fail verification depending on how you connect.
+// 		ServerName: host,
+// 	}, nil
+// }
+
+func buildClientTLSConfig(certsDir, addr string, insecure bool) (*tls.Config, error) {
+	identityDir, err := discoverIdentityDir(certsDir)
+	if err != nil {
+		return nil, err
+	}
+
+	clientCertPath := filepath.Join(identityDir, "client.crt")
+	clientKeyPath := filepath.Join(identityDir, "client.key")
+	clientCert, err := tls.LoadX509KeyPair(clientCertPath, clientKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("load client keypair (%s): %w", identityDir, err)
+	}
+
+	caPath := filepath.Join(certsDir, "ca.crt")
+	caPEM, err := os.ReadFile(caPath)
+	if err != nil {
+		return nil, fmt.Errorf("read ca.crt: %w", err)
+	}
+	roots := x509.NewCertPool()
+	if ok := roots.AppendCertsFromPEM(caPEM); !ok {
+		return nil, fmt.Errorf("append ca.crt: no certs found")
+	}
+
+	host := addr
+	// addr might be "host:port"
+	if h, _, err := net.SplitHostPort(addr); err == nil {
+		host = h
+	}
+
+	tlsCfg := &tls.Config{
+		MinVersion:   tls.VersionTLS13,
+		Certificates: []tls.Certificate{clientCert},
+		RootCAs:      roots,
+		ServerName:   host,
+	}
+
+	if insecure {
+		tlsCfg.InsecureSkipVerify = true // dev-only
+	}
+	return tlsCfg, nil
+}
+
+func discoverIdentityDir(certsDir string) (string, error) {
+	entries, err := os.ReadDir(certsDir)
+	if err != nil {
+		return "", err
+	}
+
+	var found string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		d := filepath.Join(certsDir, e.Name())
+		if fileExists(filepath.Join(d, "client.crt")) && fileExists(filepath.Join(d, "client.key")) {
+			if found != "" {
+				return "", fmt.Errorf("multiple identities found under %s; specify one", certsDir)
+			}
+			found = d
+		}
+	}
+	if found == "" {
+		return "", fmt.Errorf("no identity found under %s", certsDir)
+	}
+	return found, nil
+}
+
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}

--- a/cmd/jobworker-server/grpcServer.go
+++ b/cmd/jobworker-server/grpcServer.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/bucknercd/jobworker/internal/manager"
+	jobpb "github.com/bucknercd/jobworker/proto/gen/jobpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type grpcServer struct {
+	jobpb.UnimplementedJobWorkerServer
+	logger *log.Logger
+	mgr    *manager.Manager
+}
+
+func NewGRPCServer(logger *log.Logger, mgr *manager.Manager) jobpb.JobWorkerServer {
+	return &grpcServer{logger: logger, mgr: mgr}
+}
+
+func (s *grpcServer) StartJob(ctx context.Context, req *jobpb.StartJobRequest) (*jobpb.StartJobResponse, error) {
+	user, err := mtlsUserFromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "mTLS identity: %v", err)
+	}
+
+	// For now: log it. Next step: pass it to manager/joblib for authz/auditing.
+	s.logger.Printf("StartJob user=%s exe=%q args=%v", user, req.GetExecutable(), req.GetArgs())
+
+	return s.mgr.StartJob(ctx, req)
+}
+
+func (s *grpcServer) StopJob(ctx context.Context, req *jobpb.StopJobRequest) (*jobpb.StopJobResponse, error) {
+	return s.mgr.StopJob(ctx, req)
+}
+
+func (s *grpcServer) GetStatus(ctx context.Context, req *jobpb.GetStatusRequest) (*jobpb.GetStatusResponse, error) {
+	return s.mgr.GetStatus(ctx, req)
+}
+
+func (s *grpcServer) StreamOutput(req *jobpb.StreamOutputRequest, stream jobpb.JobWorker_StreamOutputServer) error {
+	// Not implemented in manager yet; keep it explicit.
+	// If you already have it in joblib, we can wire next.
+	return jobpb.UnimplementedJobWorkerServer{}.StreamOutput(req, stream)
+}

--- a/cmd/jobworker-server/main.go
+++ b/cmd/jobworker-server/main.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/bucknercd/jobworker/internal/manager"
+	jobpb "github.com/bucknercd/jobworker/proto/gen/jobpb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+// ---- MAIN ----
+
+func main() {
+	var (
+		listenAddr = flag.String("listen", ":50051", "listen address")
+		certsDir   = flag.String("certs", "./certs", "certs directory")
+		logPath    = flag.String("log", "./jobworker-server.log", "server log file")
+	)
+	flag.Parse()
+
+	lf, err := os.OpenFile(*logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		log.Fatalf("open log file: %v", err)
+	}
+
+	logger := log.New(lf, "", log.LstdFlags|log.Lmsgprefix)
+	logger.SetPrefix("[jobworker-server] ")
+
+	abs, _ := filepath.Abs(*logPath)
+	logger.Printf("logging to %s", abs)
+
+	tlsCfg, err := buildServerTLSConfig(*certsDir)
+	if err != nil {
+		logger.Fatalf("tls config: %v", err)
+	}
+
+	lis, err := net.Listen("tcp", *listenAddr)
+	if err != nil {
+		logger.Fatalf("listen %s: %v", *listenAddr, err)
+	}
+	grpcServer := grpc.NewServer(grpc.Creds(credentials.NewTLS(tlsCfg)))
+
+	mgr := manager.NewManager(logger)
+	jobpb.RegisterJobWorkerServer(grpcServer, NewGRPCServer(logger, mgr))
+
+	logger.Printf("listening on %s", *listenAddr)
+	if err := grpcServer.Serve(lis); err != nil {
+		logger.Fatalf("serve: %v", err)
+	}
+}
+
+// --- TLS helpers ---
+
+func buildServerTLSConfig(certsDir string) (*tls.Config, error) {
+	// server cert/key
+	certPath := filepath.Join(certsDir, "server.crt")
+	keyPath := filepath.Join(certsDir, "server.key")
+	serverCert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("load server keypair: %w", err)
+	}
+
+	// client CA bundle
+	caPath := filepath.Join(certsDir, "ca.crt")
+	caPEM, err := os.ReadFile(caPath)
+	if err != nil {
+		return nil, fmt.Errorf("read ca.crt: %w", err)
+	}
+	clientCAs := x509.NewCertPool()
+	if ok := clientCAs.AppendCertsFromPEM(caPEM); !ok {
+		return nil, fmt.Errorf("append ca.crt: no certs found")
+	}
+
+	return &tls.Config{
+		MinVersion:   tls.VersionTLS13,
+		Certificates: []tls.Certificate{serverCert},
+
+		ClientCAs:  clientCAs,
+		ClientAuth: tls.RequireAndVerifyClientCert,
+
+		// Good hygiene
+		PreferServerCipherSuites: true,
+	}, nil
+}

--- a/cmd/jobworker-server/mtlsUser.go
+++ b/cmd/jobworker-server/mtlsUser.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+)
+
+func mtlsUserFromContext(ctx context.Context) (string, error) {
+	p, ok := peer.FromContext(ctx)
+	if !ok || p.AuthInfo == nil {
+		return "", fmt.Errorf("no peer auth info")
+	}
+
+	ti, ok := p.AuthInfo.(credentials.TLSInfo)
+	if !ok {
+		return "", fmt.Errorf("unexpected auth info type: %T", p.AuthInfo)
+	}
+
+	if len(ti.State.PeerCertificates) == 0 {
+		return "", fmt.Errorf("no peer certificates")
+	}
+
+	cn := ti.State.PeerCertificates[0].Subject.CommonName
+	if cn == "" {
+		return "", fmt.Errorf("peer cert CN is empty")
+	}
+	return cn, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 toolchain go1.23.11
 
 require (
+	github.com/google/uuid v1.6.0
 	google.golang.org/grpc v1.74.2
 	google.golang.org/protobuf v1.36.7
 )

--- a/internal/cgroups/cgroups.go
+++ b/internal/cgroups/cgroups.go
@@ -1,24 +1,341 @@
 package cgroups
 
-import "path/filepath"
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
 
 const (
-	jobCgroupPath = "/sys/fs/cgroup/jobs"
+	jobCgroupRoot = "/sys/fs/cgroup/jobs"
 )
 
 type CgroupManager struct {
 	cgPath string
 }
 
-func NewCgroupManager(jobId string) *CgroupManager {
-	return &CgroupManager{cgPath: filepath.Join(jobCgroupPath, jobId)}
+type Snapshot struct {
+	Path string
+
+	PidsCurrent int
+	Procs       []int
+
+	CPUMax    string
+	MemoryMax string
+	IOMax     string
+
+	MemoryCurrent uint64
+
+	CPUStat map[string]uint64
 }
 
-func (m *CgroupManager) Create(jobID string, limits []string) (int, error) {
-	// Implementation for creating a cgroup; return cgroup file descriptor for a dir
-	return 0, nil
+func NewCgroupManager(jobID string) *CgroupManager {
+	return &CgroupManager{cgPath: filepath.Join(jobCgroupRoot, jobID)}
 }
-func (m *CgroupManager) Delete(jobID string) error {
-	// Implementation for removing a cgroup
+
+// Create ensures the parent cgroup delegates controllers, creates the job cgroup,
+// applies limits, and returns an FD opened on the job cgroup directory suitable
+// for SysProcAttr{UseCgroupFD: true, CgroupFD: fd}.
+func (m *CgroupManager) Create(jobID string, limits []string) (int, error) {
+	if jobID == "" {
+		return -1, fmt.Errorf("jobID required")
+	}
+
+	// Basic sanity: cgroup v2 expects this file to exist.
+	if _, err := os.Stat("/sys/fs/cgroup/cgroup.controllers"); err != nil {
+		return -1, fmt.Errorf("cgroup v2 not available: %w", err)
+	}
+
+	// Ensure root exists.
+	if err := os.MkdirAll(jobCgroupRoot, 0o755); err != nil {
+		return -1, fmt.Errorf("mkdir %s: %w", jobCgroupRoot, err)
+	}
+
+	// Ensure controllers are delegated to children of /jobs.
+	// Without this, job cgroups won't have cpu.max/memory.max/io.max/etc.
+	if err := ensureDelegatedControllers(jobCgroupRoot, []string{"cpu", "memory", "io", "pids"}); err != nil {
+		// Treat this as a hard error: without controller delegation, per-job limits won't exist.
+		return -1, err
+	}
+
+	// Create the job cgroup dir.
+	if err := os.MkdirAll(m.cgPath, 0o755); err != nil {
+		return -1, fmt.Errorf("mkdir %s: %w", m.cgPath, err)
+	}
+
+	// Apply limits (now the controller files should exist if delegation succeeded).
+	if err := applyLimits(m.cgPath, limits); err != nil {
+		_ = m.Delete(jobID) // best-effort rollback
+		return -1, err
+	}
+
+	// Open FD on the job cgroup directory for UseCgroupFD.
+	fd, err := syscall.Open(m.cgPath, syscall.O_DIRECTORY|syscall.O_RDONLY|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		_ = m.Delete(jobID)
+		return -1, fmt.Errorf("open cgroup dir fd: %w", err)
+	}
+
+	return fd, nil
+}
+
+// ensureDelegatedControllers ensures that parent has the requested controllers enabled
+// in cgroup.subtree_control so children get controller interface files.
+//
+// IMPORTANT: This often requires root or systemd delegation. If it fails with EPERM,
+// you need to run jobworker-server with appropriate privileges or configure systemd
+// Delegate=yes for the service and create a delegated slice.
+func ensureDelegatedControllers(parent string, want []string) error {
+	controllersPath := filepath.Join(parent, "cgroup.controllers")
+	subtreePath := filepath.Join(parent, "cgroup.subtree_control")
+
+	ctrlBytes, err := os.ReadFile(controllersPath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", controllersPath, err)
+	}
+	available := make(map[string]bool)
+	for _, c := range strings.Fields(string(ctrlBytes)) {
+		available[c] = true
+	}
+
+	// Only try to enable controllers that are actually available here.
+	var enable []string
+	for _, c := range want {
+		if available[c] {
+			enable = append(enable, c)
+		}
+	}
+	if len(enable) == 0 {
+		return fmt.Errorf("no requested controllers available under %s (have: %s)", parent, strings.TrimSpace(string(ctrlBytes)))
+	}
+
+	// Check what's already enabled to avoid unnecessary writes.
+	curBytes, err := os.ReadFile(subtreePath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", subtreePath, err)
+	}
+	cur := make(map[string]bool)
+	for _, c := range strings.Fields(string(curBytes)) {
+		cur[c] = true
+	}
+
+	var toWrite []string
+	for _, c := range enable {
+		if !cur[c] {
+			toWrite = append(toWrite, "+"+c)
+		}
+	}
+	if len(toWrite) == 0 {
+		return nil // already delegated
+	}
+
+	// cgroup.subtree_control expects space-separated "+controller" tokens.
+	payload := strings.Join(toWrite, " ") + "\n"
+	if err := os.WriteFile(subtreePath, []byte(payload), 0o644); err != nil {
+		// Make the error message extremely actionable.
+		return fmt.Errorf(
+			"enable controllers on %s failed: %w (tried %q). "+
+				"Without delegation, per-job files like cpu.max/memory.max will not appear. "+
+				"Run as root or configure systemd delegation (Delegate=yes) for the service.",
+			subtreePath, err, strings.TrimSpace(payload),
+		)
+	}
 	return nil
+}
+
+// Delete kills remaining tasks (best effort) and removes the job cgroup directory.
+// NOTE: if your job is still running and you rely on cmd.Wait() to reap, call Stop() first.
+func (m *CgroupManager) Delete(jobID string) error {
+	if jobID == "" {
+		return fmt.Errorf("jobID required")
+	}
+
+	if _, err := os.Stat(m.cgPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("stat cgroup: %w", err)
+	}
+
+	_ = os.WriteFile(filepath.Join(m.cgPath, "cgroup.kill"), []byte("1"), 0o644)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		empty, err := cgroupEmpty(filepath.Join(m.cgPath, "cgroup.procs"))
+		if err != nil {
+			break
+		}
+		if empty {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Use RemoveAll because the cgroup dir contains pseudo-files; os.Remove often fails.
+	if err := os.RemoveAll(m.cgPath); err != nil {
+		return fmt.Errorf("remove cgroup dir %s: %w", m.cgPath, err)
+	}
+	return nil
+}
+
+func applyLimits(cgPath string, limits []string) error {
+	for _, raw := range limits {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(raw, "=")
+		if !ok {
+			return fmt.Errorf("invalid limit format %q (expected key=value)", raw)
+		}
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if k == "" || v == "" {
+			return fmt.Errorf("invalid limit %q (empty key or value)", raw)
+		}
+
+		switch k {
+		case "cpu.max", "memory.max", "io.max":
+		default:
+			return fmt.Errorf("unsupported cgroup limit key %q", k)
+		}
+
+		path := filepath.Join(cgPath, k)
+
+		// Make missing controller files an explicit, helpful error.
+		if _, err := os.Stat(path); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf(
+					"cgroup file %s does not exist (controller not delegated?). "+
+						"Ensure %s has controllers enabled in cgroup.subtree_control",
+					path, jobCgroupRoot,
+				)
+			}
+			return fmt.Errorf("stat %s: %w", path, err)
+		}
+
+		if err := os.WriteFile(path, []byte(v+"\n"), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func cgroupEmpty(procsPath string) (bool, error) {
+	b, err := os.ReadFile(procsPath)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(b)) == "", nil
+}
+
+func (m *CgroupManager) Snapshot() (*Snapshot, error) {
+	s := &Snapshot{Path: m.cgPath, CPUStat: map[string]uint64{}}
+
+	// Membership
+	if v, err := readInt(filepath.Join(m.cgPath, "pids.current")); err == nil {
+		s.PidsCurrent = v
+	}
+	if procs, err := readProcs(filepath.Join(m.cgPath, "cgroup.procs")); err == nil {
+		s.Procs = procs
+	}
+
+	// Limits (read back exactly what kernel sees)
+	s.CPUMax, _ = readTrim(filepath.Join(m.cgPath, "cpu.max"))
+	s.MemoryMax, _ = readTrim(filepath.Join(m.cgPath, "memory.max"))
+	s.IOMax, _ = readTrim(filepath.Join(m.cgPath, "io.max"))
+
+	// Usage
+	if v, err := readUint64(filepath.Join(m.cgPath, "memory.current")); err == nil {
+		s.MemoryCurrent = v
+	}
+	if st, err := readKeyVals(filepath.Join(m.cgPath, "cpu.stat")); err == nil {
+		s.CPUStat = st
+	}
+
+	// If the cgroup doesn’t have controllers enabled, these files won’t exist.
+	// Snapshot should still succeed and return partial data.
+	return s, nil
+}
+
+func readTrim(p string) (string, error) {
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+func readInt(p string) (int, error) {
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return 0, err
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(b)))
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+func readUint64(p string) (uint64, error) {
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return 0, err
+	}
+	n, err := strconv.ParseUint(strings.TrimSpace(string(b)), 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+func readProcs(p string) ([]int, error) {
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return nil, err
+	}
+	var out []int
+	for _, line := range strings.Fields(string(b)) {
+		n, err := strconv.Atoi(strings.TrimSpace(line))
+		if err != nil {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out, nil
+}
+
+func readKeyVals(p string) (map[string]uint64, error) {
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]uint64{}
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) != 2 {
+			continue
+		}
+		v, err := strconv.ParseUint(parts[1], 10, 64)
+		if err != nil {
+			continue
+		}
+		out[parts[0]] = v
+	}
+	return out, nil
+}
+
+// Optional helper: detect "file missing" without blowing up logs.
+func IsNotExist(err error) bool {
+	return errors.Is(err, os.ErrNotExist)
 }

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -1,0 +1,139 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/bucknercd/jobworker/internal/joblib"
+	jobpb "github.com/bucknercd/jobworker/proto/gen/jobpb"
+)
+
+type Manager struct {
+	mu   sync.RWMutex
+	jobs map[string]*joblib.Job
+
+	logger *log.Logger
+}
+
+func NewManager(logger *log.Logger) *Manager {
+	return &Manager{
+		jobs:   make(map[string]*joblib.Job),
+		logger: logger,
+	}
+}
+
+// StartJob: creates job, starts it, stores in map, and returns job id.
+// NOTE: This currently uses UUID as job id. You can swap to your base36 sortable id later.
+func (m *Manager) StartJob(ctx context.Context, req *jobpb.StartJobRequest) (*jobpb.StartJobResponse, error) {
+	if req.GetExecutable() == "" {
+		return nil, status.Error(codes.InvalidArgument, "executable required")
+	}
+
+	id := uuid.New().String()
+
+	limits := translateLimits(req.GetLimits()) // TODO: upgrade later
+
+	job, err := joblib.NewJob(id, req.GetExecutable(), req.GetArgs(), limits, m.logger)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "create job: %v", err)
+	}
+
+	if err := job.Start(); err != nil {
+		return nil, status.Errorf(codes.Internal, "start job: %v", err)
+	}
+
+	m.mu.Lock()
+	m.jobs[id] = job
+	m.mu.Unlock()
+
+	// Reap in background; keep job in map for now (you can add TTL cleanup later).
+	go func() {
+		<-job.Done()
+		m.logger.Printf("job %s done status=%s exit=%d", id, job.Status(), job.ExitCode())
+	}()
+
+	return &jobpb.StartJobResponse{JobId: id}, nil
+}
+
+func (m *Manager) StopJob(ctx context.Context, req *jobpb.StopJobRequest) (*jobpb.StopJobResponse, error) {
+	job := m.getJob(req.GetJobId())
+	if job == nil {
+		return nil, status.Error(codes.NotFound, "job not found")
+	}
+
+	if err := job.Stop(); err != nil {
+		return nil, status.Errorf(codes.Internal, "stop job: %v", err)
+	}
+
+	return &jobpb.StopJobResponse{
+		Metadata: &jobpb.JobMetadata{
+			User:     "", // filled by server auth layer later
+			Status:   mapStatus(job.Status()),
+			ExitCode: job.ExitCode(),
+		},
+	}, nil
+}
+
+func (m *Manager) GetStatus(ctx context.Context, req *jobpb.GetStatusRequest) (*jobpb.GetStatusResponse, error) {
+	job := m.getJob(req.GetJobId())
+	if job == nil {
+		return nil, status.Error(codes.NotFound, "job not found")
+	}
+
+	return &jobpb.GetStatusResponse{
+		JobId: req.GetJobId(),
+		Metadata: &jobpb.JobMetadata{
+			User:     "", // filled by server auth layer later
+			Status:   mapStatus(job.Status()),
+			ExitCode: job.ExitCode(),
+		},
+	}, nil
+}
+
+func (m *Manager) getJob(id string) *joblib.Job {
+	if id == "" {
+		return nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.jobs[id]
+}
+
+func translateLimits(l *jobpb.ResourceLimits) []string {
+	if l == nil {
+		return nil
+	}
+
+	// Minimal translation for now:
+	// You probably want to parse cpu/mem strings into cpu.max/memory.max eventually.
+	// For now, return empty and rely on defaults (or hardcode defaults inside joblib/cgroups).
+	return nil
+}
+
+// mapStatus maps internal joblib.Status -> proto JobStatus
+func mapStatus(s joblib.Status) jobpb.JobStatus {
+	switch s {
+	case joblib.StatusRunning:
+		return jobpb.JobStatus_JOB_STATUS_RUNNING
+	case joblib.StatusExited:
+		return jobpb.JobStatus_JOB_STATUS_EXITED
+	case joblib.StatusStopped:
+		return jobpb.JobStatus_JOB_STATUS_STOPPED
+	case joblib.StatusFailed:
+		return jobpb.JobStatus_JOB_STATUS_FAILED
+	default:
+		return jobpb.JobStatus_JOB_STATUS_UNSPECIFIED
+	}
+}
+
+func (m *Manager) DebugDump() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return fmt.Sprintf("jobs=%d", len(m.jobs))
+}

--- a/scripts/ctest.sh
+++ b/scripts/ctest.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This script checks that a job with given PID has been properly
+# placed into its cgroup, and that limits/accounting are working.
+
+PID=$1
+
+if [ -z $PID ]; then
+    echo "PID is required. First and only args"
+    exit 1
+fi
+
+# 1) find your job cgroup dir
+ls /sys/fs/cgroup/jobs
+
+# assume it’s /sys/fs/cgroup/jobs/<jobid>
+cg=/sys/fs/cgroup/jobs/$PID
+
+# 2) confirm attachment
+cat $cg/cgroup.procs
+cat $cg/pids.current
+
+# 3) confirm limits were set
+cat $cg/cpu.max
+cat $cg/memory.max
+cat $cg/io.max
+
+# 4) confirm accounting changes while job runs
+cat $cg/cpu.stat | head
+cat $cg/memory.current
+


### PR DESCRIPTION
- Add jobworker-server and jobctl (gRPC over TLS)
- Enforce per-job cgroup v2 limits via UseCgroupFD + controller delegation
- Log job PID + cgroup snapshot (limits/usage/throttling) at start
- Persist per-job stdout/stderr to disk and dump to server log on completion
- Expand Makefile build/run targets and cert generation (SAN support)
- Add README describing current behavior (no chroot, no streaming)